### PR TITLE
Add FastAPI backend and simple frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+matchups.db
+__pycache__/

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Backend API
+
+This folder contains a simple FastAPI backend for the FIFA Matchup Generator.
+
+## Setup
+
+Install the Python dependencies:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+Run the development server:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+The API will start on `http://127.0.0.1:8000` with interactive docs available at `/docs`.

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,15 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = 'sqlite:///./matchups.db'
+
+engine = create_engine(DATABASE_URL, connect_args={'check_same_thread': False})
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,153 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+from collections import defaultdict
+
+from . import models, schemas
+from .database import engine, Base, get_db
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="FIFA Matchup Generator")
+
+# Predefined clubs with tiers
+DEFAULT_CLUBS = {
+    1: ["Real Madrid", "PSG"],
+    2: ["Chelsea", "Liverpool"],
+}
+
+@app.on_event("startup")
+def populate_clubs():
+    db = next(get_db())
+    for tier, clubs in DEFAULT_CLUBS.items():
+        for name in clubs:
+            if not db.query(models.Club).filter_by(name=name).first():
+                db.add(models.Club(name=name, tier=tier))
+    db.commit()
+
+@app.get("/clubs", response_model=dict)
+def get_clubs(db: Session = Depends(get_db)):
+    clubs = db.query(models.Club).all()
+    by_tier = defaultdict(list)
+    for c in clubs:
+        by_tier[c.tier].append(schemas.ClubRead.from_orm(c))
+    return {tier: [club.model_dump() for club in clubs] for tier, clubs in by_tier.items()}
+
+@app.post("/players", response_model=schemas.PlayerRead)
+def create_player(player: schemas.PlayerCreate, db: Session = Depends(get_db)):
+    db_player = models.Player(username=player.username)
+    db.add(db_player)
+    db.commit()
+    db.refresh(db_player)
+    return db_player
+
+@app.get("/players", response_model=list[schemas.PlayerRead])
+def list_players(db: Session = Depends(get_db)):
+    return db.query(models.Player).order_by(models.Player.username).all()
+
+@app.post("/matches", response_model=schemas.MatchRead)
+def create_match(match: schemas.MatchCreate, db: Session = Depends(get_db)):
+    db_match = models.Match(
+        team_a_club_id=match.team_a_club_id,
+        team_b_club_id=match.team_b_club_id,
+        team_a_score=match.team_a_score,
+        team_b_score=match.team_b_score,
+    )
+    db.add(db_match)
+    db.commit()
+    db.refresh(db_match)
+    # players
+    for mp in match.players:
+        db_mp = models.MatchPlayer(match_id=db_match.id, player_id=mp.player_id, team=mp.team)
+        db.add(db_mp)
+    db.commit()
+    db.refresh(db_match)
+    return db_match
+
+@app.get("/matches", response_model=list[schemas.MatchRead])
+def list_matches(db: Session = Depends(get_db), user: int | None = None, club: int | None = None):
+    query = db.query(models.Match)
+    if club:
+        query = query.filter((models.Match.team_a_club_id == club) | (models.Match.team_b_club_id == club))
+    matches = query.order_by(models.Match.date.desc()).all()
+    result = []
+    for m in matches:
+        if user:
+            if not any(mp.player_id == user for mp in m.players):
+                continue
+        result.append(m)
+    return result
+
+@app.get("/leaderboard/individual", response_model=list[schemas.LeaderboardEntry])
+def individual_leaderboard(db: Session = Depends(get_db)):
+    players = db.query(models.Player).all()
+    entries = []
+    for p in players:
+        matches = db.query(models.MatchPlayer).filter_by(player_id=p.id).all()
+        stats = {
+            "matches": 0,
+            "wins": 0,
+            "losses": 0,
+            "draws": 0,
+            "goals_for": 0,
+            "goals_against": 0,
+        }
+        for mp in matches:
+            stats["matches"] += 1
+            match = db.query(models.Match).get(mp.match_id)
+            if mp.team == 1:
+                gf = match.team_a_score
+                ga = match.team_b_score
+            else:
+                gf = match.team_b_score
+                ga = match.team_a_score
+            stats["goals_for"] += gf
+            stats["goals_against"] += ga
+            if gf > ga:
+                stats["wins"] += 1
+            elif gf < ga:
+                stats["losses"] += 1
+            else:
+                stats["draws"] += 1
+        win_rate = stats["wins"] / stats["matches"] * 100 if stats["matches"] else 0
+        entries.append(schemas.LeaderboardEntry(name=p.username, win_rate=win_rate, **stats))
+    entries.sort(key=lambda e: e.win_rate, reverse=True)
+    return entries
+
+@app.get("/leaderboard/team", response_model=list[schemas.LeaderboardEntry])
+def team_leaderboard(db: Session = Depends(get_db)):
+    # compute team combinations
+    combos: dict[tuple[int, ...], dict] = {}
+    matches = db.query(models.Match).all()
+    for m in matches:
+        team_players = {1: [], 2: []}
+        for mp in m.players:
+            team_players[mp.team].append(mp.player_id)
+        for team, players in team_players.items():
+            key = tuple(sorted(players))
+            stats = combos.setdefault(key, {
+                'matches': 0, 'wins': 0, 'losses': 0,
+                'draws': 0, 'goals_for': 0, 'goals_against': 0,
+            })
+            stats['matches'] += 1
+            if team == 1:
+                gf = m.team_a_score
+                ga = m.team_b_score
+            else:
+                gf = m.team_b_score
+                ga = m.team_a_score
+            stats['goals_for'] += gf
+            stats['goals_against'] += ga
+            if gf > ga:
+                stats['wins'] += 1
+            elif gf < ga:
+                stats['losses'] += 1
+            else:
+                stats['draws'] += 1
+    results = []
+    for players, stats in combos.items():
+        names = db.query(models.Player).filter(models.Player.id.in_(players)).all()
+        name = ' + '.join(p.username for p in names)
+        win_rate = stats['wins'] / stats['matches'] * 100 if stats['matches'] else 0
+        results.append(schemas.LeaderboardEntry(name=name, win_rate=win_rate, **stats))
+    results.sort(key=lambda e: e.win_rate, reverse=True)
+    return results

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from .database import Base
+
+class Club(Base):
+    __tablename__ = 'clubs'
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    tier = Column(Integer, nullable=False)
+
+class Player(Base):
+    __tablename__ = 'players'
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, nullable=False)
+
+class Match(Base):
+    __tablename__ = 'matches'
+    id = Column(Integer, primary_key=True, index=True)
+    date = Column(DateTime, default=datetime.utcnow)
+    team_a_club_id = Column(Integer, ForeignKey('clubs.id'))
+    team_b_club_id = Column(Integer, ForeignKey('clubs.id'))
+    team_a_score = Column(Integer)
+    team_b_score = Column(Integer)
+
+    team_a_club = relationship('Club', foreign_keys=[team_a_club_id])
+    team_b_club = relationship('Club', foreign_keys=[team_b_club_id])
+    players = relationship('MatchPlayer', back_populates='match')
+
+class MatchPlayer(Base):
+    __tablename__ = 'match_players'
+    match_id = Column(Integer, ForeignKey('matches.id'), primary_key=True)
+    player_id = Column(Integer, ForeignKey('players.id'), primary_key=True)
+    team = Column(Integer, nullable=False)  # 1 or 2
+
+    match = relationship('Match', back_populates='players')
+    player = relationship('Player')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+sqlalchemy

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from typing import List, Dict
+from pydantic import BaseModel
+
+class ClubBase(BaseModel):
+    name: str
+    tier: int
+
+class ClubCreate(ClubBase):
+    pass
+
+class ClubRead(ClubBase):
+    id: int
+    model_config = dict(from_attributes=True)
+
+class PlayerBase(BaseModel):
+    username: str
+
+class PlayerCreate(PlayerBase):
+    pass
+
+class PlayerRead(PlayerBase):
+    id: int
+    model_config = dict(from_attributes=True)
+
+class MatchPlayerCreate(BaseModel):
+    player_id: int
+    team: int
+
+class MatchCreate(BaseModel):
+    team_a_club_id: int
+    team_b_club_id: int
+    team_a_score: int
+    team_b_score: int
+    players: List[MatchPlayerCreate]
+
+class MatchPlayerRead(BaseModel):
+    player: PlayerRead
+    team: int
+    model_config = dict(from_attributes=True)
+
+class MatchRead(BaseModel):
+    id: int
+    date: datetime
+    team_a_club: ClubRead
+    team_b_club: ClubRead
+    team_a_score: int
+    team_b_score: int
+    players: List[MatchPlayerRead]
+    model_config = dict(from_attributes=True)
+
+class LeaderboardEntry(BaseModel):
+    name: str
+    matches: int
+    wins: int
+    losses: int
+    draws: int
+    goals_for: int
+    goals_against: int
+    win_rate: float

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,131 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useState } from 'react'
 import './App.css'
 
+const API = 'http://127.0.0.1:8000'
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [clubs, setClubs] = useState({})
+  const [players, setPlayers] = useState([])
+  const [matches, setMatches] = useState([])
+  const [username, setUsername] = useState('')
+  const [form, setForm] = useState({
+    teamAClub: '',
+    teamBClub: '',
+    teamAScore: 0,
+    teamBScore: 0,
+    teamAPlayers: '',
+    teamBPlayers: '',
+  })
+
+  const fetchData = async () => {
+    const clubsRes = await fetch(`${API}/clubs`)
+    setClubs(await clubsRes.json())
+    const playersRes = await fetch(`${API}/players`)
+    if (playersRes.ok) setPlayers(await playersRes.json())
+    const matchesRes = await fetch(`${API}/matches`)
+    if (matchesRes.ok) setMatches(await matchesRes.json())
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const addPlayer = async () => {
+    const res = await fetch(`${API}/players`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username }),
+    })
+    if (res.ok) {
+      setUsername('')
+      fetchData()
+    }
+  }
+
+  const createMatch = async () => {
+    const body = {
+      team_a_club_id: parseInt(form.teamAClub),
+      team_b_club_id: parseInt(form.teamBClub),
+      team_a_score: parseInt(form.teamAScore),
+      team_b_score: parseInt(form.teamBScore),
+      players: [
+        ...form.teamAPlayers.split(',').map((id) => ({ player_id: parseInt(id), team: 1 })),
+        ...form.teamBPlayers.split(',').map((id) => ({ player_id: parseInt(id), team: 2 })),
+      ],
+    }
+    const res = await fetch(`${API}/matches`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (res.ok) {
+      setForm({ teamAClub: '', teamBClub: '', teamAScore: 0, teamBScore: 0, teamAPlayers: '', teamBPlayers: '' })
+      fetchData()
+    } else {
+      alert('error creating match')
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="App">
+      <h1>FIFA Matchups</h1>
+      <section>
+        <h2>Add Player</h2>
+        <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="username" />
+        <button onClick={addPlayer}>Add</button>
+        <ul>
+          {players.map((p) => (
+            <li key={p.id}>{p.id}: {p.username}</li>
+          ))}
+        </ul>
+      </section>
+      <section>
+        <h2>Create Match</h2>
+        <div>
+          <label>Team A Club:</label>
+          <select value={form.teamAClub} onChange={(e) => setForm({ ...form, teamAClub: e.target.value })}>
+            <option value="">select</option>
+            {Object.values(clubs).flat().map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label>Team B Club:</label>
+          <select value={form.teamBClub} onChange={(e) => setForm({ ...form, teamBClub: e.target.value })}>
+            <option value="">select</option>
+            {Object.values(clubs).flat().map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label>Team A Players (ids comma separated):</label>
+          <input value={form.teamAPlayers} onChange={(e) => setForm({ ...form, teamAPlayers: e.target.value })} />
+        </div>
+        <div>
+          <label>Team B Players (ids comma separated):</label>
+          <input value={form.teamBPlayers} onChange={(e) => setForm({ ...form, teamBPlayers: e.target.value })} />
+        </div>
+        <div>
+          <label>Score A:</label>
+          <input type="number" value={form.teamAScore} onChange={(e) => setForm({ ...form, teamAScore: e.target.value })} />
+          <label>Score B:</label>
+          <input type="number" value={form.teamBScore} onChange={(e) => setForm({ ...form, teamBScore: e.target.value })} />
+        </div>
+        <button onClick={createMatch}>Submit Match</button>
+      </section>
+      <section>
+        <h2>Matches</h2>
+        <ul>
+          {matches.map((m) => (
+            <li key={m.id}>
+              {new Date(m.date).toLocaleString()} - Team A {m.team_a_club.name} {m.team_a_score} vs {m.team_b_score} {m.team_b_club.name}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- implement Python FastAPI backend with SQLite database
- add models for clubs, players, matches
- expose endpoints for clubs, players, matches and leaderboards
- provide README instructions to run the backend
- update React frontend to interact with API and display data

## Testing
- `npm install`
- `npm run lint`
- `uvicorn backend.main:app --port 8000 --reload` *(manual server start)*
- `curl http://127.0.0.1:8000/clubs`

------
https://chatgpt.com/codex/tasks/task_e_68812bdaa3988326b62690fdd03c1f3c