### PR TITLE
Fix club dropdown by enabling CORS

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from collections import defaultdict
 
@@ -8,6 +9,15 @@ from .database import engine, Base, get_db
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="FIFA Matchup Generator")
+
+# Allow frontend applications (e.g. Vite dev server) to access the API
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
 
 # Predefined clubs with tiers
 DEFAULT_CLUBS = {


### PR DESCRIPTION
## Summary
- allow cross-origin requests from the frontend to the FastAPI backend

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688133f915f48326ba845b8510018ad5