### PR TITLE
Add admin delete endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,3 +17,14 @@ uvicorn backend.main:app --reload
 ```
 
 The API will start on `http://127.0.0.1:8000` with interactive docs available at `/docs`.
+
+## Admin actions
+
+Two additional endpoints allow administrators to remove players and matches from the database:
+
+```http
+DELETE /players/{player_id}
+DELETE /matches/{match_id}
+```
+
+Requests to these endpoints must include an `X-Admin-Token` header matching the token configured in `backend/main.py` (default is `secret`).


### PR DESCRIPTION
## Summary
- restrict admin operations using a simple token
- allow admins to delete players and matches
- document the new endpoints

## Testing
- `pip install -r backend/requirements.txt`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68813b25a55c8326a4423136ea34294d