### PR TITLE
Add leaderboard page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -111,3 +111,20 @@ li {
   font-size: 1.25rem;
   font-weight: 700;
 }
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+.leaderboard-table th,
+.leaderboard-table td {
+  border: 1px solid #dce8ff;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.leaderboard-table th {
+  background: #f0f7ff;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import Home from './Home.jsx'
 import AdminPage from './AdminPage.jsx'
+import Leaderboard from './Leaderboard.jsx'
 import './App.css'
 
 const API = 'http://127.0.0.1:8000'
@@ -113,7 +114,9 @@ function App() {
   return (
     <Router>
       <nav>
-        <Link to="/">Home</Link> | <Link to="/admin">Admin</Link>
+        <Link to="/">Home</Link> |{' '}
+        <Link to="/admin">Admin</Link> |{' '}
+        <Link to="/leaderboard">Leaderboard</Link>
       </nav>
       <Routes>
         <Route
@@ -148,6 +151,7 @@ function App() {
             />
           )}
         />
+        <Route path="/leaderboard" element={<Leaderboard />} />
       </Routes>
     </Router>
   )

--- a/src/Leaderboard.jsx
+++ b/src/Leaderboard.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react'
+
+const API = 'http://127.0.0.1:8000'
+
+export default function Leaderboard() {
+  const [individual, setIndividual] = useState([])
+  const [teams, setTeams] = useState([])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const indRes = await fetch(`${API}/leaderboard/individual`)
+      if (indRes.ok) {
+        setIndividual(await indRes.json())
+      }
+      const teamRes = await fetch(`${API}/leaderboard/team`)
+      if (teamRes.ok) {
+        const data = await teamRes.json()
+        const filtered = data.filter((e) => e.name.split(' + ').length === 2)
+        setTeams(filtered)
+      }
+    }
+    fetchData()
+  }, [])
+
+  const renderTable = (entries) => (
+    <table className="leaderboard-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Matches</th>
+          <th>Wins</th>
+          <th>Losses</th>
+          <th>Draws</th>
+          <th>Goals For</th>
+          <th>Goals Against</th>
+          <th>Win %</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((e) => (
+          <tr key={e.name}>
+            <td>{e.name}</td>
+            <td>{e.matches}</td>
+            <td>{e.wins}</td>
+            <td>{e.losses}</td>
+            <td>{e.draws}</td>
+            <td>{e.goals_for}</td>
+            <td>{e.goals_against}</td>
+            <td>{e.win_rate.toFixed(1)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+
+  return (
+    <div className="App">
+      <h1>Leaderboard</h1>
+      <section>
+        <h2>Individual</h2>
+        {renderTable(individual)}
+      </section>
+      <section>
+        <h2>Teams of Two</h2>
+        {renderTable(teams)}
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `Leaderboard` page with tables for individual and two-player team stats
- link new page from navigation and route
- add basic table styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68813fa3a86c832687bce6cc032b1a5e