### PR TITLE
Improve layout spacing and rounded styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,14 +1,15 @@
 .App {
   background: rgba(255, 255, 255, 0.85);
   padding: 2rem;
-  border-radius: 8px;
+  border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   border: 1px solid #d0e4ff;
 }
 
 nav {
   display: flex;
-  gap: 1rem;
+  justify-content: center;
+  gap: 1.5rem;
   background: #1565c0;
   padding: 0.75rem 1rem;
   border-radius: 8px;
@@ -32,7 +33,7 @@ h1 {
 }
 
 section {
-  margin-bottom: 2rem;
+  margin-bottom: 2.5rem;
 }
 
 section h2 {
@@ -51,20 +52,21 @@ input,
 select {
   width: 100%;
   padding: 0.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
   border: 1px solid #bcd5ff;
-  border-radius: 4px;
+  border-radius: 6px;
   font-size: 1rem;
 }
 
 button {
   padding: 0.6em 1.2em;
   border: none;
-  border-radius: 4px;
+  border-radius: 20px;
   background-color: #1e88e5;
   color: #fff;
   cursor: pointer;
   font-size: 1rem;
+  margin-bottom: 0.5rem;
   transition: background-color 0.2s;
 }
 
@@ -93,7 +95,8 @@ li {
 
 .score-inputs {
   display: flex;
-  gap: 1rem;
+  gap: 2rem;
+  flex-wrap: wrap;
   align-items: center;
 }
 
@@ -103,9 +106,9 @@ li {
 
 .match-item {
   margin-bottom: 1rem;
-  padding: 0.75rem;
+  padding: 1rem;
   border: 1px solid #dce8ff;
-  border-radius: 4px;
+  border-radius: 8px;
   background: #fff;
 }
 
@@ -143,6 +146,8 @@ li {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1rem;
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .leaderboard-table th,

--- a/src/index.css
+++ b/src/index.css
@@ -4,12 +4,13 @@ body {
   background: linear-gradient(135deg, #e3f2fd, #e0f7fa);
   min-height: 100vh;
   color: #333;
+  padding: 1rem;
 }
 
 #root {
   max-width: 960px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 3rem;
 }
 
 a {


### PR DESCRIPTION
## Summary
- update main body padding
- center navigation links and increase spacing
- round buttons, inputs and match boxes
- add spacing tweaks across the app

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688142e948a0832686f96000bbff2bb7