### PR TITLE
UI layout improvements with loading spinner

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -100,6 +100,37 @@ li {
   align-items: center;
 }
 
+.club-inputs,
+.player-inputs {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.club-inputs > div,
+.player-inputs > div {
+  flex: 1;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #1e88e5;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  animation: spin 1s linear infinite;
+  margin: 0 auto;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .score-inputs input {
   width: 100%;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ function App() {
   const [tierClubs, setTierClubs] = useState([]);
   const [username, setUsername] = useState("");
   const [adminToken, setAdminToken] = useState("");
+  const [creatingMatch, setCreatingMatch] = useState(false);
   const [form, setForm] = useState({
     teamAClub: "",
     teamBClub: "",
@@ -63,6 +64,8 @@ function App() {
   };
 
   const createMatch = async () => {
+    if (creatingMatch) return;
+    setCreatingMatch(true);
     const body = {
       team_a_club_id: parseInt(form.teamAClub),
       team_b_club_id: parseInt(form.teamBClub),
@@ -82,6 +85,7 @@ function App() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
+    setCreatingMatch(false);
     if (res.ok) {
       setForm({
         teamAClub: "",
@@ -143,6 +147,7 @@ function App() {
               form={form}
               setForm={setForm}
               createMatch={createMatch}
+              creatingMatch={creatingMatch}
               matches={matches}
             />
           }

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -12,6 +12,7 @@ export default function Home({
   form,
   setForm,
   createMatch,
+  creatingMatch,
   matches,
 }) {
   return (
@@ -37,51 +38,59 @@ export default function Home({
         <h2>Create Match</h2>
         <button onClick={randomizeTier}>Random Tier</button>
         {selectedTier && <div>Selected Tier: {selectedTier}</div>}
-        <div>
-          <label>Team A Club:</label>
-          <select
-            value={form.teamAClub}
-            onChange={(e) => setForm({ ...form, teamAClub: e.target.value })}
-          >
-            <option value="">select</option>
-            {(tierClubs.length ? tierClubs : Object.values(clubs).flat()).map(
-              (c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              )
-            )}
-          </select>
+        <div className="club-inputs">
+          <div>
+            <label>Team A Club:</label>
+            <select
+              value={form.teamAClub}
+              onChange={(e) => setForm({ ...form, teamAClub: e.target.value })}
+            >
+              <option value="">select</option>
+              {(tierClubs.length ? tierClubs : Object.values(clubs).flat()).map(
+                (c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                )
+              )}
+            </select>
+          </div>
+          <div>
+            <label>Team B Club:</label>
+            <select
+              value={form.teamBClub}
+              onChange={(e) => setForm({ ...form, teamBClub: e.target.value })}
+            >
+              <option value="">select</option>
+              {(tierClubs.length ? tierClubs : Object.values(clubs).flat()).map(
+                (c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                )
+              )}
+            </select>
+          </div>
         </div>
-        <div>
-          <label>Team B Club:</label>
-          <select
-            value={form.teamBClub}
-            onChange={(e) => setForm({ ...form, teamBClub: e.target.value })}
-          >
-            <option value="">select</option>
-            {(tierClubs.length ? tierClubs : Object.values(clubs).flat()).map(
-              (c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              )
-            )}
-          </select>
-        </div>
-        <div>
-          <label>Team A Players (ids comma separated):</label>
-          <input
-            value={form.teamAPlayers}
-            onChange={(e) => setForm({ ...form, teamAPlayers: e.target.value })}
-          />
-        </div>
-        <div>
-          <label>Team B Players (ids comma separated):</label>
-          <input
-            value={form.teamBPlayers}
-            onChange={(e) => setForm({ ...form, teamBPlayers: e.target.value })}
-          />
+        <div className="player-inputs">
+          <div>
+            <label>Team A Players (ids comma separated):</label>
+            <input
+              value={form.teamAPlayers}
+              onChange={(e) =>
+                setForm({ ...form, teamAPlayers: e.target.value })
+              }
+            />
+          </div>
+          <div>
+            <label>Team B Players (ids comma separated):</label>
+            <input
+              value={form.teamBPlayers}
+              onChange={(e) =>
+                setForm({ ...form, teamBPlayers: e.target.value })
+              }
+            />
+          </div>
         </div>
         <div className="score-inputs">
           <div>
@@ -101,7 +110,9 @@ export default function Home({
             />
           </div>
         </div>
-        <button onClick={createMatch}>Submit Match</button>
+        <button onClick={createMatch} disabled={creatingMatch}>
+          {creatingMatch ? <div className="spinner" /> : "Submit Match"}
+        </button>
       </section>
       <section>
         <h2>Matches</h2>


### PR DESCRIPTION
## Summary
- align club and player inputs side by side in match form
- show loading spinner while submitting matches
- disable submit button during the request

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688273e5f1648326ba3afcd64ed7dca0