### PR TITLE
Add loading states to UI buttons

### DIFF
--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -7,6 +7,8 @@ export default function AdminPage({
   matches,
   deletePlayer,
   deleteMatch,
+  deletingPlayerIds,
+  deletingMatchIds,
 }) {
   return (
     <div className="App">
@@ -21,8 +23,16 @@ export default function AdminPage({
         {players.map((p) => (
           <li key={p.id}>
             {p.id}: {p.username}{' '}
-            <button className="danger" onClick={() => deletePlayer(p.id)}>
-              Delete
+            <button
+              className="danger"
+              onClick={() => deletePlayer(p.id)}
+              disabled={deletingPlayerIds.includes(p.id)}
+            >
+              {deletingPlayerIds.includes(p.id) ? (
+                <div className="spinner" />
+              ) : (
+                'Delete'
+              )}
             </button>
           </li>
         ))}
@@ -32,8 +42,16 @@ export default function AdminPage({
         {matches.map((m) => (
           <li key={m.id}>
             {m.team_a_club.name} vs {m.team_b_club.name}{' '}
-            <button className="danger" onClick={() => deleteMatch(m.id)}>
-              Delete
+            <button
+              className="danger"
+              onClick={() => deleteMatch(m.id)}
+              disabled={deletingMatchIds.includes(m.id)}
+            >
+              {deletingMatchIds.includes(m.id) ? (
+                <div className="spinner" />
+              ) : (
+                'Delete'
+              )}
             </button>
           </li>
         ))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,10 @@ function App() {
   const [username, setUsername] = useState("");
   const [adminToken, setAdminToken] = useState("");
   const [creatingMatch, setCreatingMatch] = useState(false);
+  const [addingPlayer, setAddingPlayer] = useState(false);
+  const [randomizingTier, setRandomizingTier] = useState(false);
+  const [deletingPlayerIds, setDeletingPlayerIds] = useState([]);
+  const [deletingMatchIds, setDeletingMatchIds] = useState([]);
   const [form, setForm] = useState({
     teamAClub: "",
     teamBClub: "",
@@ -35,8 +39,10 @@ function App() {
   };
 
   const randomizeTier = async () => {
+    if (randomizingTier) return;
     const tiers = Object.keys(clubs);
     if (tiers.length === 0) return;
+    setRandomizingTier(true);
     const randTier = tiers[Math.floor(Math.random() * tiers.length)];
     setSelectedTier(parseInt(randTier));
     const res = await fetch(`${API}/clubs?tier=${randTier}`);
@@ -45,6 +51,7 @@ function App() {
       setTierClubs(data[randTier] || []);
       setForm({ ...form, teamAClub: "", teamBClub: "" });
     }
+    setRandomizingTier(false);
   };
 
   useEffect(() => {
@@ -52,14 +59,19 @@ function App() {
   }, []);
 
   const addPlayer = async () => {
+    if (addingPlayer) return;
+    setAddingPlayer(true);
     const res = await fetch(`${API}/players`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username }),
     });
+    setAddingPlayer(false);
     if (res.ok) {
       setUsername("");
       fetchData();
+    } else {
+      alert("failed to add player");
     }
   };
 
@@ -102,10 +114,13 @@ function App() {
   };
 
   const deletePlayer = async (id) => {
+    if (deletingPlayerIds.includes(id)) return;
+    setDeletingPlayerIds((ids) => [...ids, id]);
     const res = await fetch(`${API}/players/${id}`, {
       method: "DELETE",
       headers: { "X-Admin-Token": adminToken },
     });
+    setDeletingPlayerIds((ids) => ids.filter((i) => i !== id));
     if (res.ok) {
       fetchData();
     } else {
@@ -114,10 +129,13 @@ function App() {
   };
 
   const deleteMatch = async (id) => {
+    if (deletingMatchIds.includes(id)) return;
+    setDeletingMatchIds((ids) => [...ids, id]);
     const res = await fetch(`${API}/matches/${id}`, {
       method: "DELETE",
       headers: { "X-Admin-Token": adminToken },
     });
+    setDeletingMatchIds((ids) => ids.filter((i) => i !== id));
     if (res.ok) {
       fetchData();
     } else {
@@ -140,8 +158,10 @@ function App() {
               setUsername={setUsername}
               players={players}
               addPlayer={addPlayer}
+              addingPlayer={addingPlayer}
               clubs={clubs}
               randomizeTier={randomizeTier}
+              randomizingTier={randomizingTier}
               selectedTier={selectedTier}
               tierClubs={tierClubs}
               form={form}
@@ -162,6 +182,8 @@ function App() {
               matches={matches}
               deletePlayer={deletePlayer}
               deleteMatch={deleteMatch}
+              deletingPlayerIds={deletingPlayerIds}
+              deletingMatchIds={deletingMatchIds}
             />
           }
         />

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -5,8 +5,10 @@ export default function Home({
   setUsername,
   players,
   addPlayer,
+  addingPlayer,
   clubs,
   randomizeTier,
+  randomizingTier,
   selectedTier,
   tierClubs,
   form,
@@ -25,7 +27,9 @@ export default function Home({
           onChange={(e) => setUsername(e.target.value)}
           placeholder="username"
         />
-        <button onClick={addPlayer}>Add</button>
+        <button onClick={addPlayer} disabled={addingPlayer}>
+          {addingPlayer ? <div className="spinner" /> : "Add"}
+        </button>
         <ul>
           {players.map((p) => (
             <li key={p.id}>
@@ -36,7 +40,9 @@ export default function Home({
       </section>
       <section>
         <h2>Create Match</h2>
-        <button onClick={randomizeTier}>Random Tier</button>
+        <button onClick={randomizeTier} disabled={randomizingTier}>
+          {randomizingTier ? <div className="spinner" /> : "Random Tier"}
+        </button>
         {selectedTier && <div>Selected Tier: {selectedTier}</div>}
         <div className="club-inputs">
           <div>


### PR DESCRIPTION
## Summary
- prevent multiple submissions by adding loading indicators to all async buttons
- disable Add Player, Random Tier, and delete buttons while processing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688275aa3cdc8326aaf1c101d5112cf0