### PR TITLE
Allow selecting multiple players by name

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,8 +25,8 @@ function App() {
     teamBClub: "",
     teamAScore: 0,
     teamBScore: 0,
-    teamAPlayers: "",
-    teamBPlayers: "",
+    teamAPlayers: [],
+    teamBPlayers: [],
   });
 
   const fetchData = async () => {
@@ -84,12 +84,14 @@ function App() {
       team_a_score: parseInt(form.teamAScore),
       team_b_score: parseInt(form.teamBScore),
       players: [
-        ...form.teamAPlayers
-          .split(",")
-          .map((id) => ({ player_id: parseInt(id), team: 1 })),
-        ...form.teamBPlayers
-          .split(",")
-          .map((id) => ({ player_id: parseInt(id), team: 2 })),
+        ...form.teamAPlayers.map((id) => ({
+          player_id: parseInt(id),
+          team: 1,
+        })),
+        ...form.teamBPlayers.map((id) => ({
+          player_id: parseInt(id),
+          team: 2,
+        })),
       ],
     };
     const res = await fetch(`${API}/matches`, {
@@ -104,8 +106,8 @@ function App() {
         teamBClub: "",
         teamAScore: 0,
         teamBScore: 0,
-        teamAPlayers: "",
-        teamBPlayers: "",
+        teamAPlayers: [],
+        teamBPlayers: [],
       });
       fetchData();
     } else {

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -80,22 +80,46 @@ export default function Home({
         </div>
         <div className="player-inputs">
           <div>
-            <label>Team A Players (ids comma separated):</label>
-            <input
+            <label>Team A Players:</label>
+            <select
+              multiple
               value={form.teamAPlayers}
               onChange={(e) =>
-                setForm({ ...form, teamAPlayers: e.target.value })
+                setForm({
+                  ...form,
+                  teamAPlayers: Array.from(e.target.selectedOptions).map(
+                    (o) => o.value
+                  ),
+                })
               }
-            />
+            >
+              {players.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.username}
+                </option>
+              ))}
+            </select>
           </div>
           <div>
-            <label>Team B Players (ids comma separated):</label>
-            <input
+            <label>Team B Players:</label>
+            <select
+              multiple
               value={form.teamBPlayers}
               onChange={(e) =>
-                setForm({ ...form, teamBPlayers: e.target.value })
+                setForm({
+                  ...form,
+                  teamBPlayers: Array.from(e.target.selectedOptions).map(
+                    (o) => o.value
+                  ),
+                })
               }
-            />
+            >
+              {players.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.username}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
         <div className="score-inputs">


### PR DESCRIPTION
## Summary
- use array-based team player state
- build match body from selected player IDs
- change team player inputs to multi-select dropdowns

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68827780f1f883268dd81db40f49d1a8