### PR TITLE
Add checkbox selection for players

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,6 +112,18 @@ li {
   flex: 1;
 }
 
+.player-checkbox-list {
+  border: 1px solid #bcd5ff;
+  border-radius: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.player-checkbox-list li {
+  margin-bottom: 0.25rem;
+}
+
 .spinner {
   border: 4px solid #f3f3f3;
   border-top: 4px solid #1e88e5;

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -81,45 +81,53 @@ export default function Home({
         <div className="player-inputs">
           <div>
             <label>Team A Players:</label>
-            <select
-              multiple
-              value={form.teamAPlayers}
-              onChange={(e) =>
-                setForm({
-                  ...form,
-                  teamAPlayers: Array.from(e.target.selectedOptions).map(
-                    (o) => o.value
-                  ),
-                })
-              }
-            >
+            <ul className="player-checkbox-list">
               {players.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.username}
-                </option>
+                <li key={p.id}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={form.teamAPlayers.includes(String(p.id))}
+                      onChange={() => {
+                        const id = String(p.id);
+                        setForm((f) => ({
+                          ...f,
+                          teamAPlayers: f.teamAPlayers.includes(id)
+                            ? f.teamAPlayers.filter((pid) => pid !== id)
+                            : [...f.teamAPlayers, id],
+                        }));
+                      }}
+                    />
+                    {p.username}
+                  </label>
+                </li>
               ))}
-            </select>
+            </ul>
           </div>
           <div>
             <label>Team B Players:</label>
-            <select
-              multiple
-              value={form.teamBPlayers}
-              onChange={(e) =>
-                setForm({
-                  ...form,
-                  teamBPlayers: Array.from(e.target.selectedOptions).map(
-                    (o) => o.value
-                  ),
-                })
-              }
-            >
+            <ul className="player-checkbox-list">
               {players.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.username}
-                </option>
+                <li key={p.id}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={form.teamBPlayers.includes(String(p.id))}
+                      onChange={() => {
+                        const id = String(p.id);
+                        setForm((f) => ({
+                          ...f,
+                          teamBPlayers: f.teamBPlayers.includes(id)
+                            ? f.teamBPlayers.filter((pid) => pid !== id)
+                            : [...f.teamBPlayers, id],
+                        }));
+                      }}
+                    />
+                    {p.username}
+                  </label>
+                </li>
               ))}
-            </select>
+            </ul>
           </div>
         </div>
         <div className="score-inputs">


### PR DESCRIPTION
## Summary
- let users pick players using checkboxes instead of multi-select lists
- style the new checkbox lists

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688278a4aba483269e01df2ea38c4bea