### PR TITLE
Add Cloud SQL example app

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,4 +15,4 @@ COPY . .
 EXPOSE 8080
 
 # Start FastAPI with uvicorn (adjust if using Flask)
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "cloud_main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/cloud_db.py
+++ b/backend/cloud_db.py
@@ -1,0 +1,72 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+# google cloud sql connector for secure connections
+from google.cloud.sql.connector import Connector, IPTypes
+import pg8000
+
+# Environment variables for Cloud SQL
+DB_USER = os.getenv("DB_USER")
+DB_PASS = os.getenv("DB_PASS")
+DB_NAME = os.getenv("DB_NAME")
+INSTANCE_CONNECTION_NAME = os.getenv("INSTANCE_CONNECTION_NAME")  # "project:region:instance"
+
+# Optional settings for local development
+DB_HOST = os.getenv("DB_HOST", "127.0.0.1")
+DB_PORT = int(os.getenv("DB_PORT", 5432))
+
+connector = Connector()
+
+
+def getconn():
+    """Create a new database connection using the Cloud SQL Python Connector.
+
+    Falls back to a TCP connection when INSTANCE_CONNECTION_NAME is not set
+    (useful for local development). Any failure raises RuntimeError so the
+    calling code can handle database errors gracefully.
+    """
+    try:
+        if INSTANCE_CONNECTION_NAME:
+            # Connect via the Cloud SQL Python Connector using pg8000 driver
+            conn = connector.connect(
+                INSTANCE_CONNECTION_NAME,
+                "pg8000",
+                user=DB_USER,
+                password=DB_PASS,
+                db=DB_NAME,
+                ip_type=IPTypes.PUBLIC,
+            )
+            return conn
+        # Fallback to standard TCP connection for local usage
+        return pg8000.connect(
+            user=DB_USER,
+            password=DB_PASS,
+            host=DB_HOST,
+            port=DB_PORT,
+            database=DB_NAME,
+        )
+    except Exception as exc:
+        raise RuntimeError(f"Failed to connect to database: {exc}") from exc
+
+
+# SQLAlchemy engine with connection pooling
+engine = create_engine(
+    "postgresql+pg8000://",
+    creator=getconn,
+    pool_pre_ping=True,  # validate connections
+    pool_size=5,
+    max_overflow=2,
+)
+
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+Base = declarative_base()
+
+
+def get_db():
+    """Provide a session to path operations."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/cloud_main.py
+++ b/backend/cloud_main.py
@@ -1,0 +1,38 @@
+"""Example FastAPI app for Google Cloud Run using Cloud SQL Postgres."""
+
+from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy.orm import Session
+
+from .cloud_db import Base, engine, get_db
+from .cloud_models import NameEntry
+
+app = FastAPI(title="Cloud Run Sample")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Create database tables on service startup."""
+    Base.metadata.create_all(bind=engine)
+
+
+@app.get("/")
+def read_names(db: Session = Depends(get_db)):
+    """Return all stored names."""
+    try:
+        return db.query(NameEntry).all()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post("/add/{name}")
+def add_name(name: str, db: Session = Depends(get_db)):
+    """Insert a new row into the NameEntry table."""
+    try:
+        entry = NameEntry(name=name)
+        db.add(entry)
+        db.commit()
+        db.refresh(entry)
+        return entry
+    except Exception as exc:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/cloud_models.py
+++ b/backend/cloud_models.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String
+from .cloud_db import Base
+
+
+class NameEntry(Base):
+    """Simple table storing names."""
+
+    __tablename__ = "name_entries"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 sqlalchemy
 psycopg2-binary>=2.9.9
+pg8000>=1.29.2
+cloud-sql-python-connector>=1.4.1


### PR DESCRIPTION
## Summary
- create FastAPI example for Cloud Run with Cloud SQL connection
- configure SQLAlchemy connection pooling using Cloud SQL Python connector
- create sample NameEntry model and endpoints
- update Dockerfile and requirements

## Testing
- `pip install -r backend/requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6882a0a143748326b15b23186acf061e